### PR TITLE
display emoji in directory list

### DIFF
--- a/src/components/Directory/DirectoryListItem.tsx
+++ b/src/components/Directory/DirectoryListItem.tsx
@@ -4,6 +4,7 @@ import { VFC, useState, MouseEvent } from 'react';
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from 'reactstrap';
 import styled from 'styled-components';
 
+import { Emoji } from 'emoji-mart';
 import { Directory } from '~/domains/Directory';
 import { BootstrapBreakpoints, BootstrapColor, BootstrapIcon } from '~/interfaces/variables';
 
@@ -46,7 +47,7 @@ export const DirectoryListItem: VFC<Props> = ({ directory }) => {
     <Link href={`/directory/${directory._id}`}>
       <StyledList className="d-flex" role="button">
         <div className="w-100 text-truncate">
-          <Icon icon={BootstrapIcon.DIRECTORY} color={BootstrapColor.LIGHT} />
+          <Emoji emoji={directory.emojiId} size={20} />
           <span className="ms-3" role="button">
             {directory.name}
           </span>

--- a/src/components/Sidebar/SidebarDirectory.tsx
+++ b/src/components/Sidebar/SidebarDirectory.tsx
@@ -4,7 +4,10 @@ import styled from 'styled-components';
 
 import { DragDropContext, Droppable, Draggable, DragUpdate } from 'react-beautiful-dnd';
 
+import { Emoji } from 'emoji-mart';
 import { DirectoryItem } from '../Directory/DirectoryItem';
+
+import { openFileFolderEmoji } from '~/const/emoji';
 import { restClient } from '~/utils/rest-client';
 import { toastError, toastSuccess } from '~/utils/toastr';
 
@@ -90,6 +93,7 @@ export const SidebarDirectory: VFC = () => {
                     {(provided) => (
                       <div key={directory._id} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} className="my-1">
                         <DirectoryItem directory={directory} onClickDirectory={handleClickDirectory} activeDirectoryId={directoryId as string} />
+                        <Emoji emoji={openFileFolderEmoji} size={40} />
                       </div>
                     )}
                   </Draggable>

--- a/src/components/Sidebar/SidebarDirectory.tsx
+++ b/src/components/Sidebar/SidebarDirectory.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { DragDropContext, Droppable, Draggable, DragUpdate } from 'react-beautiful-dnd';
 
 import { DirectoryItem } from '../Directory/DirectoryItem';
-
 import { restClient } from '~/utils/rest-client';
 import { toastError, toastSuccess } from '~/utils/toastr';
 

--- a/src/components/Sidebar/SidebarDirectory.tsx
+++ b/src/components/Sidebar/SidebarDirectory.tsx
@@ -4,10 +4,8 @@ import styled from 'styled-components';
 
 import { DragDropContext, Droppable, Draggable, DragUpdate } from 'react-beautiful-dnd';
 
-import { Emoji } from 'emoji-mart';
 import { DirectoryItem } from '../Directory/DirectoryItem';
 
-import { openFileFolderEmoji } from '~/const/emoji';
 import { restClient } from '~/utils/rest-client';
 import { toastError, toastSuccess } from '~/utils/toastr';
 
@@ -93,7 +91,6 @@ export const SidebarDirectory: VFC = () => {
                     {(provided) => (
                       <div key={directory._id} ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps} className="my-1">
                         <DirectoryItem directory={directory} onClickDirectory={handleClickDirectory} activeDirectoryId={directoryId as string} />
-                        <Emoji emoji={openFileFolderEmoji} size={40} />
                       </div>
                     )}
                   </Draggable>


### PR DESCRIPTION
# 対象のIssue

fix #531 
- folder iconではなく emojiに変更しました。
<img width="856" alt="Screen Shot 2021-06-29 at 7 25 27" src="https://user-images.githubusercontent.com/59536731/123711281-32e7ee80-d8ab-11eb-8c3d-ff0fea0f6eb2.png">

emojiの位置調整に関しては後続タスク #546 にて修正される予定です。