### PR TITLE
Imprv/#9y2f74 position adjustment on directory list

### DIFF
--- a/src/components/Directory/DirectoryItem.tsx
+++ b/src/components/Directory/DirectoryItem.tsx
@@ -99,7 +99,7 @@ export const DirectoryItem: VFC<Props> = ({ directory, onClickDirectory, activeD
         {directory && (
           <div className="text-truncate">
             <StyledEmojiWrapper>
-              <Emoji emoji={directory.emojiId} size={18} />
+              <Emoji emoji={directory.emojiId} size={20} />
             </StyledEmojiWrapper>
             <span className="ms-2">{directory.name}</span>
           </div>

--- a/src/components/Directory/DirectoryListItem.tsx
+++ b/src/components/Directory/DirectoryListItem.tsx
@@ -47,7 +47,9 @@ export const DirectoryListItem: VFC<Props> = ({ directory }) => {
     <Link href={`/directory/${directory._id}`}>
       <StyledList className="d-flex" role="button">
         <div className="w-100 text-truncate">
-          <Emoji emoji={directory.emojiId} size={20} />
+          <StyledEmojiWrapper>
+            <Emoji emoji={directory.emojiId} size={20} />
+          </StyledEmojiWrapper>
           <span className="ms-3" role="button">
             {directory.name}
           </span>
@@ -83,6 +85,12 @@ export const DirectoryListItem: VFC<Props> = ({ directory }) => {
     </Link>
   );
 };
+
+const StyledEmojiWrapper = styled.span`
+  .emoji-mart-emoji {
+    vertical-align: text-bottom;
+  }
+`;
 
 const StyledList = styled.li<{ isActive?: boolean }>`
   padding: 10px;


### PR DESCRIPTION
# 対象のClick up のリンク

## 変更点の説明
- Derectory listにある絵文字とテキストの位置調整をしました。
### Before
![Screen Shot 2021-07-03 at 15 36 06](https://user-images.githubusercontent.com/59536731/124345577-b17abe00-dc14-11eb-8fbe-275ffc00316c.png)

### After
![Screen Shot 2021-07-03 at 15 36 14](https://user-images.githubusercontent.com/59536731/124345579-b50e4500-dc14-11eb-97d3-f86cf014ff8a.png)

- emoji sizeは20に統一
![Screen Shot 2021-07-03 at 15 44 15](https://user-images.githubusercontent.com/59536731/124345774-cc99fd80-dc15-11eb-8e5e-c29f73b5a104.png)
