### PR TITLE
CardPreview の title が 3行表示されると表示が崩れる

### DIFF
--- a/src/components/organisms/OgpPreviewCard.tsx
+++ b/src/components/organisms/OgpPreviewCard.tsx
@@ -28,7 +28,7 @@ export const OgpPreviewCard: VFC<Props> = ({ page, onClickCard }) => {
         decoding="sync"
       />
       <StyledDivRgiht className="px-3 py-2 d-flex flex-column">
-        <StyledTitle className="small fw-bold text-break mb-0">{title || url}</StyledTitle>
+        <StyledTitle className="small fw-bold text-break mb-0 overflow-hidden">{title || url}</StyledTitle>
         <StyledDescription className="small text-truncate mb-0">
           {description?.length > MAX_WORD_COUNT_OF_BODY ? description?.substr(0, MAX_WORD_COUNT_OF_BODY) + '...' : description}
         </StyledDescription>


### PR DESCRIPTION
# 対象のClick up のリンク
https://app.clickup.com/t/abzk00
## 変更点の説明

## 動作確認の方法

## その他(optional)
